### PR TITLE
Fix: 리팩토링 및 한글 인코딩 문제 해결

### DIFF
--- a/include/course_db.h
+++ b/include/course_db.h
@@ -6,9 +6,9 @@
 #include <iostream>
 #include "course.h"
 
-typedef std::set<const Course*> Courses;
+typedef std::set<const Course*> CoursePtrSet;
 
-std::set<std::string> seperate_str(std::string::iterator, std::string::iterator, int);
+std::set<std::string> get_token(const std::string&, int);
 
 struct CourseQuery
 {
@@ -44,9 +44,10 @@ struct DateIndexKeyHash { // for using index key in unordered map's key.
 
 class CourseDatabase
 {
-std::unordered_map<int, Course> courses;
-std::unordered_map<DateIndexKey, Courses, DateIndexKeyHash> date_index;
-std::unordered_map<std::string, Courses> name_index;
+std::unordered_map<int, Course> course_by_id;
+std::set<Course*> course_ptrs;
+std::unordered_map<DateIndexKey, CoursePtrSet, DateIndexKeyHash> date_index;
+std::unordered_map<std::string, CoursePtrSet> name_index;
 
 public:
 CourseDatabase();

--- a/include/parser.h
+++ b/include/parser.h
@@ -8,6 +8,8 @@ struct ParseResult
     bool is_success;
     std::string tag;
     std::string value;
+
+    bool operator==(const std::string&) const;
 };
 
 // Parse tag and tag's contents

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,5 +1,10 @@
 #include "parser.h"
 
+bool ParseResult::operator==(const std::string &tag) const
+{
+    return this->tag == tag;
+}
+
 // Parse tag and tag's contents
 ParseResult parse_tag(std::string::const_iterator &pt, const std::string::const_iterator &end)
 {


### PR DESCRIPTION
- ParseResult에 operator==(std::string)을 추가해 결과를 이용해 바로 특정태그인지 확인 할 수 있도록 수정
- query 내부 로직 수정 (불필요한 변수 제거 및 분기처리)
- 한글으로된 이름 검색시 토큰 분리가 잘 안되는 인코딩 문제 수정. (wstring 이용)